### PR TITLE
[PR] Allow the definition of multiple columns and image count per column in Media Wall

### DIFF
--- a/includes/wsuwp-media-wall.php
+++ b/includes/wsuwp-media-wall.php
@@ -363,7 +363,10 @@ class WSUWP_Media_Wall {
 					for ( $z = 0; $z < $image_count; $z++ ) {
 						$current_image = array_pop( $wall_images );
 						if ( isset( $current_image['hosted_image_url'] ) ) {
-							$wall_html .= '<img ' . $width . $height . 'src="' . esc_url( $current_image['hosted_image_url'] ) . '">';
+							$wall_html .= '
+								<a href="' . $current_image['original_share_url'] . '">
+									<img ' . $width . $height . 'src="' . esc_url( $current_image['hosted_image_url'] ) . '">
+								</a>';
 						}
 					}
 				}


### PR DESCRIPTION
The `columns` attribute can now be sued with the `[wsu_media_wall]` shortcode to specify number of images per column.

`[wsu_media_wall columns="2,3,2"]` will output 3 columns with 2, 3, and 2 images each.
