### PR TITLE
[PR] Check the WSU Alerts feed every minute and display when active

### DIFF
--- a/parts/before-main.php
+++ b/parts/before-main.php
@@ -1,5 +1,7 @@
 <?php
 
+echo wsu_home_get_alert();
+
 /*
  * On the home page, we display a series of navigation menus at the top.
  */

--- a/style.css
+++ b/style.css
@@ -34,6 +34,30 @@ body {
 	padding: 0;
 }
 
+.wsu-home-alert {
+	height: 100px;
+	margin: 0;
+	padding: 0;
+	text-align: center;
+	background: #f15d22;
+	font-size: 1rem;
+}
+
+.wsu-home-alert h1 {
+	font-size: 1.7em;
+	margin: 0;
+	padding: 10px 0 0 0;
+	width: 100%;
+	text-align: center;
+	background: none;
+}
+
+.wsu-home-alert a {
+	font-size: 1.5em;
+	line-height: 1.6em;
+	color: #efefef;
+}
+
 /*---------------------------- header ----------------------------*/
 .home .main-header {
 	background: #fff;


### PR DESCRIPTION
Check the feed used for WSU alerts and display the most recent
item in the emergency category. If no items are available, then
do not show an alert.

The feed is cached for a minute and we cache the entire HTML block
for a minute. In the future, we'll do this smarter.
