### PR TITLE
[PR] Don't output height and width on media wall images, favor CSS

### DIFF
--- a/includes/wsuwp-media-wall.php
+++ b/includes/wsuwp-media-wall.php
@@ -372,7 +372,7 @@ class WSUWP_Media_Wall {
 						if ( isset( $current_image['hosted_image_url'] ) ) {
 							$wall_html .= '
 								<a href="' . $current_image['original_share_url'] . '">
-									<img ' . $width . $height . ' src="' . esc_url( get_stylesheet_directory_uri() . '/images/blank.gif' ) . '" data-src="' . esc_url( $current_image['hosted_image_url'] ) . '" class="media-wall-image">
+									<img src="' . esc_url( get_stylesheet_directory_uri() . '/images/blank.gif' ) . '" data-src="' . esc_url( $current_image['hosted_image_url'] ) . '" class="media-wall-image">
 								</a>';
 						}
 					}


### PR DESCRIPTION
IE8 takes inline width attributes seriously and would not listen
to reason when told that its max width should be 100%. We don't
need the width attribute for other browsers here.