### PR TITLE
Use `get_site()` vs `wsuwp_get_current_site()`

### DIFF
--- a/parts/after-main.php
+++ b/parts/after-main.php
@@ -22,7 +22,7 @@ if ( is_front_page() || wsu_home_is_site( 'wsu-features' ) || wsu_home_is_site( 
 	 * home site.
 	 */
 	if ( wsu_home_is_site( 'wsu-features' ) || wsu_home_is_site( 'wsu-impact' ) ) {
-		$feature_site = wsuwp_get_current_site();
+		$feature_site = get_site();
 		if ( isset( $feature_site->domain ) ) {
 			// Allow a local override for development.
 			$home_path = apply_filters( 'wsu_home_path', '/' );

--- a/parts/before-main.php
+++ b/parts/before-main.php
@@ -74,7 +74,7 @@ if ( is_front_page() || wsu_home_is_site( 'wsu-features' ) || wsu_home_is_site( 
 	 * home site.
 	 */
 	if ( $wsu_home_is_features ) {
-		$feature_site = wsuwp_get_current_site();
+		$feature_site = get_site();
 		if ( isset( $feature_site->domain ) ) {
 			// Allow a local override for development.
 			$home_path = apply_filters( 'wsu_home_path', '/' );

--- a/spine/offsite-navigation.php
+++ b/spine/offsite-navigation.php
@@ -2,7 +2,7 @@
 	<?php
 
 	if ( false === wsu_home_is_site( 'wsu-home' ) && false === wsu_home_is_site( 'wsu-internal' ) ) {
-		$switch_site = get_blog_details( array( 'domain' => wsuwp_get_current_site()->domain, 'path' => '/' ) );
+		$switch_site = get_blog_details( array( 'domain' => get_site()->domain, 'path' => '/' ) );
 		switch_to_blog( $switch_site->blog_id );
 	}
 

--- a/spine/site-navigation.php
+++ b/spine/site-navigation.php
@@ -2,7 +2,7 @@
 	<?php
 
 	if ( false === wsu_home_is_site( 'wsu-home' ) && false === wsu_home_is_site( 'wsu-internal' ) ) {
-		$switch_site = get_blog_details( array( 'domain' => wsuwp_get_current_site()->domain, 'path' => '/' ) );
+		$switch_site = get_blog_details( array( 'domain' => get_site()->domain, 'path' => '/' ) );
 		switch_to_blog( $switch_site->blog_id );
 	}
 


### PR DESCRIPTION
`get_site()` is a modern and appropriately named replacement.

See https://github.com/washingtonstateuniversity/WSUWP-Platform/issues/351