### PR TITLE
remove outline none from item and lighten subpages gray background

### DIFF
--- a/css/home-style.css
+++ b/css/home-style.css
@@ -689,7 +689,6 @@ span.home-headline-nav-date {
 }
 
 .home-headline-nav li:last-child a {
-	outline: none;
 	font-size: 2rem;
 	transform: translateY(-10px);
 	float: left;

--- a/css/internal-style.css
+++ b/css/internal-style.css
@@ -35,7 +35,7 @@ html body.page main {
 }
 
 .subsection_gray_background {
-	background-color: #eff0f1;
+	background-color: rgba(0, 0, 0, .015);
 }
 
 .subsection_white {


### PR DESCRIPTION
- removed `outline: none;` from home headlines
- lightened the gray background on `.subsection_gray_background`