### PR TITLE
[PR] Fix logic for enabling the home overlay meta box

### DIFF
--- a/includes/wsu-home-overlay.php
+++ b/includes/wsu-home-overlay.php
@@ -18,9 +18,10 @@ class WSU_Home_Overlay {
 	 * @param WP_Post $post      The post object of the post being edited.
 	 */
 	public function add_meta_boxes( $post_type, $post ) {
-		if ( 'page' !== $post_type && absint( get_option( 'page_on_front', false ) ) !== $post->ID ) {
+		if ( 'page' !== $post_type || absint( get_option( 'page_on_front', false ) ) !== absint( $post->ID ) ) {
 			return;
 		}
+
 		add_meta_box( 'wsu_overlay_toggle', 'Enable Overlay', array( $this, 'display_overlay_toggle' ), 'page', 'side' );
 	}
 


### PR DESCRIPTION
This should be an `OR` check rather than an `AND`. Also, because
this is a strict comparison, let's use `absint()` on both values.
The `ID` property on `$post` is likely a string.