### PR TITLE
[PR] Remove unused `sup-header` on internal pages

### DIFF
--- a/css/internal-style.css
+++ b/css/internal-style.css
@@ -343,10 +343,6 @@ div.pad-bottom {
 	padding: 0;
 }
 
-.section-life .main-header sup.sup-header, .section-about .main-header sup.sup-header, .section-admission .main-header sup.sup-header, .section-academics .main-header sup.sup-header, .section-research .main-header sup.sup-header, .section-services .main-header sup.sup-header {
-	display: none;
-}
-
 .section-life .main-header sub.sub-header, .section-about .main-header sub.sub-header, .section-admission .main-header sub.sub-header, .section-academics .main-header sub.sub-header, .section-research .main-header sub.sub-header, .section-services .main-header sub.sub-header {
 	text-align: center;
 	background-color: #981e32;

--- a/parts/headers.php
+++ b/parts/headers.php
@@ -18,15 +18,6 @@ if ( function_exists( 'wsu_home_get_page_headline' ) && is_singular( 'page' ) &&
 	?>
 	<header class="main-header">
 		<div class="header-group hgroup guttered padded-bottom short">
-
-			<sup class="sup-header"
-			     data-section="<?php echo esc_attr( $spine_main_header_values['section_title'] ); ?>"
-			     data-pagetitle="<?php echo esc_attr( $spine_main_header_values['page_title'] ); ?>"
-			     data-posttitle="<?php echo esc_attr( $spine_main_header_values['post_title'] ); ?>"
-			     data-default="<?php echo esc_html( $spine_main_header_values['sup_header_default'] ); ?>"
-			     data-alternate="<?php echo esc_html( $spine_main_header_values['sup_header_alternate'] ); ?>">
-				<span class="sup-header-default"><?php echo esc_attr( strip_tags( $spine_main_header_values['sup_header_default'], '<a>' ) ); ?></span>
-			</sup>
 			<sub class="sub-header"
 			     data-sitename="<?php echo esc_attr( $spine_main_header_values['site_name'] ); ?>"
 			     data-pagetitle="<?php echo esc_attr( $spine_main_header_values['page_title'] ); ?>"
@@ -35,7 +26,6 @@ if ( function_exists( 'wsu_home_get_page_headline' ) && is_singular( 'page' ) &&
 			     data-alternate="<?php echo esc_html( $spine_main_header_values['sub_header_alternate'] ); ?>">
 				<span class="sub-header-default"><?php echo esc_attr( strip_tags( $spine_main_header_values['sub_header_default'], '<a>' ) ); ?></span>
 			</sub>
-
 		</div>
 	</header>
 	<?php

--- a/style-guide/secondary.html
+++ b/style-guide/secondary.html
@@ -65,10 +65,7 @@
 
             <header class="main-header">
                 <div class="header-group hgroup guttered padded-bottom short">
-
-                    <sup class="sup-header" data-section="About WSU" data-pagetitle=" The WSU difference" data-posttitle=" The WSU difference" data-default="&lt;a href=&quot;https://wsu.edu/&quot; rel=&quot;home&quot;&gt;Washington State University&lt;/a&gt;" data-alternate=""><span class="sup-header-default"><a href="https://wsu.edu/" rel="home">Washington State University</a></span></sup>
                     <sub class="sub-header" data-sitename="Washington State University" data-pagetitle=" The WSU difference" data-posttitle=" The WSU difference" data-default=" The WSU difference" data-alternate=""><span class="sub-header-default"> The WSU difference</span></sub>
-
                 </div>
             </header>
 


### PR DESCRIPTION
The output of `.sup-header` was being displayed with `esc_attr()`,
which borked the display of its anchor.

This can be removed from all pages.