### PR TITLE
Don't watch CSS files in `grunt serve`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,7 +125,7 @@ module.exports = function( grunt ) {
 
 		watch: {
 			styles: {
-				files: [ "css/*.css", "src/css/*.css", "src/js/*.js" ],
+				files: [ "src/js/*.js" ],
 				tasks: [ "default" ],
 				option: {
 					livereload: 8000


### PR DESCRIPTION
This was causing an endless loop of rebuilding because of how the top 10 styles are oriented. In the future we'll want to clean this up so that all styles are loaded from src/css